### PR TITLE
Use "state: started"  for remote_syslog

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: Ensure remote_syslog is running
   service:
     name: remote_syslog
-    state: running
+    state: started
 
 - name: Set config file
   template:


### PR DESCRIPTION
Got notice when provisioning ansbile-nodejs-playbook.

[DEPRECATION WARNING]: state=running is deprecated. Please use state=started.

This feature will be removed in version 2.7.